### PR TITLE
Responsive image dimensions in Bulma

### DIFF
--- a/sass/elements/_all.sass
+++ b/sass/elements/_all.sass
@@ -6,6 +6,7 @@
 @import "content.sass"
 @import "icon.sass"
 @import "image.sass"
+@import "image_responsive_dimensions.sass"
 @import "notification.sass"
 @import "progress.sass"
 @import "table.sass"

--- a/sass/elements/image_responsive_dimensions.sass
+++ b/sass/elements/image_responsive_dimensions.sass
@@ -1,0 +1,69 @@
+$img-size-array: ( "1by1": "100%", "5by4": "80%", "4by3": "75%", "3by2": "66.6666%", "5by3": "60%", "16by9": "56.25%", "2by1": "50%", "3by1": "33.3333%", "4by5": "125%", "3by4": "133.3333%", "2by3": "150%", "3by5": "166.6666%", "9by16": "177.7777%", "1by2": "200%", "1by3": "300%" ) !default
+
+$device-size-list: "mobile", "tablet", "tablet-only", "touch", "desktop", "desktop-only", "until-widescreen", "widescreen", "widescreen-only", "until-fullhd", "fullhd" !default
+
+@if index( $device-size-list, "mobile" )
+  +mobile
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-mobile
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "tablet" )
+  +tablet
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-tablet
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "tablet-only" )
+  +tablet-only
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-tablet-only
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "touch" )
+  +touch
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-touch
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "desktop" )
+  +desktop
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-desktop
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "desktop-only" )
+  +desktop-only
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-desktop-only
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "until-widescreen" )
+  +until-widescreen
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-until-widescreen
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "widescreen" )
+  +widescreen
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-widescreen
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "widescreen-only" )
+  +widescreen-only
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-widescreen-only
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "until-fullhd" )
+  +until-fullhd
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-until-fullhd
+        padding-top: #{$img-padding} !important
+
+@if index( $device-size-list, "fullhd" )
+  +fullhd
+    @each $img-size, $img-padding in $img-size-array
+      .image.is-#{$img-size}-fullhd
+        padding-top: #{$img-padding} !important


### PR DESCRIPTION
### Responsive image dimensions
There are already some beautiful things you can do with Bulma with responsive image dimensions. 
`<figure class="image is-16by9"><img src="myimage.jpg"></figure>`
This means in Bulma, your image will be displayed with a 16 by 9 ratio.

But how can you have a different image at a different device?

I want to have a 4 by 3 dimension image at a mobile, but a 16 by 9 image at all other devices.
So, I did this:
```
<figure class="image is-16by9 is-4by3-mobile">

 <img src="myimage-fallback-for-old-browsers.jpg" 
   srcset="4by3mobile.jpg 414w 310h, 16by9image.jpg 1000w 563h">

</figure>

```
I've added a sass file for that purpose. You can adjust two variables:

```
$img-size-array
$device-size-list

```
So, if you only need a few special rules for some devices, just override this vars in your main sass file.

